### PR TITLE
fix: rename PVE node from proxmox to pve

### DIFF
--- a/terraform/modules/cloudflare/main.tf
+++ b/terraform/modules/cloudflare/main.tf
@@ -12,7 +12,7 @@ terraform {
 }
 
 locals {
-  direct_cnames  = toset(["proxmox"])
+  direct_cnames  = toset(["pve"])
   traefik_cnames = toset(["rss"])
 }
 

--- a/terraform/modules/proxmox/main.tf
+++ b/terraform/modules/proxmox/main.tf
@@ -86,7 +86,7 @@ resource "proxmox_virtual_environment_vm" "virtual_machines" {
   vm_id     = each.value.vm_id
   name      = each.value.name
   tags      = ["terraform"]
-  node_name = "proxmox"
+  node_name = "pve"
   on_boot   = true
 
   cpu {

--- a/terraform/stacks/docker/main.tf
+++ b/terraform/stacks/docker/main.tf
@@ -27,7 +27,7 @@ resource "proxmox_virtual_environment_vm" "this" {
   name      = "docker-vm"
   vm_id     = 101
   tags      = ["terraform"]
-  node_name = "proxmox"
+  node_name = "pve"
   on_boot   = true
 
   cpu {

--- a/terraform/stacks/docker/provider.tf
+++ b/terraform/stacks/docker/provider.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 provider "proxmox" {
-  endpoint  = "https://proxmox.javanese-octatonic.ts.net:8006/api2/json"
+  endpoint  = "https://pve.javanese-octatonic.ts.net:8006/api2/json"
   api_token = var.proxmox_api_token
   insecure  = true
 
@@ -17,7 +17,7 @@ provider "proxmox" {
     agent    = true
     username = "root"
     node {
-      name    = "proxmox"
+      name    = "pve"
       address = "100.85.178.8"
     }
   }

--- a/terraform/stacks/lxc/provider.tf
+++ b/terraform/stacks/lxc/provider.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 provider "proxmox" {
-  endpoint  = "https://proxmox.javanese-octatonic.ts.net:8006/api2/json"
+  endpoint  = "https://pve.javanese-octatonic.ts.net:8006/api2/json"
   api_token = var.proxmox_api_token
   insecure  = true
 
@@ -17,7 +17,7 @@ provider "proxmox" {
     agent    = true
     username = "root"
     node {
-      name    = "proxmox"
+      name    = "pve"
       address = "100.85.178.8"
     }
   }

--- a/terraform/stacks/talos/provider.tf
+++ b/terraform/stacks/talos/provider.tf
@@ -35,7 +35,7 @@ provider "tailscale" {
 provider "random" {}
 
 provider "proxmox" {
-  endpoint  = "https://proxmox.javanese-octatonic.ts.net:8006/api2/json"
+  endpoint  = "https://pve.javanese-octatonic.ts.net:8006/api2/json"
   api_token = var.proxmox_api_token
   insecure  = true
 
@@ -43,7 +43,7 @@ provider "proxmox" {
     agent    = true
     username = "root"
     node {
-      name    = "proxmox"
+      name    = "pve"
       address = "100.85.178.8"
     }
   }


### PR DESCRIPTION
- Renamed PVE node hostname from `proxmox` to `pve` on the host (`/etc/hostname`, `/etc/hosts`)
- Updated `node_name` in terraform to match
Closes #3